### PR TITLE
Migrate AWS operations documentation

### DIFF
--- a/docs/aws/database-environment-setup.md
+++ b/docs/aws/database-environment-setup.md
@@ -1,0 +1,200 @@
+# MNEMOSYS Database Environment Setup (Bootstrap)
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Environment Model](#environment-model)
+- [Infrastructure Model (Bootstrap)](#infrastructure-model-bootstrap)
+- [Naming Conventions](#naming-conventions)
+- [Bootstrap Setup Steps (Non-Production RDS)](#bootstrap-setup-steps-non-production-rds)
+  - [1) Allow local access (bootstrap only)](#1-allow-local-access-bootstrap-only)
+  - [2) Connect as the RDS master user](#2-connect-as-the-rds-master-user)
+  - [3) Create roles and set passwords](#3-create-roles-and-set-passwords)
+  - [4) Create databases and isolate access](#4-create-databases-and-isolate-access)
+  - [5) Grant schema access (sandbox/dev/test)](#5-grant-schema-access-sandboxdevtest)
+  - [6) Local environment configuration (sandbox only)](#6-local-environment-configuration-sandbox-only)
+- [Production Setup (Dedicated RDS)](#production-setup-dedicated-rds)
+- [Bootstrap Exit (Lockdown)](#bootstrap-exit-lockdown)
+
+## Purpose
+
+This document captures the concrete, repeatable steps to provision the MNEMOSYS
+databases and roles during the bootstrap phase. It is intended as an operational
+record and as a future reference.
+
+## Environment Model
+
+There are four environments:
+
+- **sandbox**: pre-PR testing for feature/bugfix/hotfix work
+- **development**: API-only deployment of `develop`
+- **test**: API-only deployment of `release`
+- **production**: API-only deployment of `main`
+
+## Infrastructure Model (Bootstrap)
+
+- Single AWS account.
+- One non-production RDS instance hosting `sandbox`, `development`, and `test`.
+- A separate RDS instance for `production` (created before real user access).
+- The non-prod RDS instance may be public during bootstrap with IP allowlisting.
+- Only the `mnemosys-admin` IAM user is used for console/CLI access.
+
+## Naming Conventions
+
+Database names:
+
+- `mnemosys_sandbox`
+- `mnemosys_dev`
+- `mnemosys_test`
+- `mnemosys_prod`
+
+Postgres roles (underscores only):
+
+- `mnemosys_sandbox_admin`, `mnemosys_sandbox_user`
+- `mnemosys_dev_admin`, `mnemosys_dev_user`
+- `mnemosys_test_admin`, `mnemosys_test_user`
+- `mnemosys_prod_admin`, `mnemosys_prod_user`
+
+## Bootstrap Setup Steps (Non-Production RDS)
+
+### 1) Allow local access (bootstrap only)
+
+Restrict inbound to your IP:
+
+```bash
+export AWS_PROFILE=mnemosys-admin
+export AWS_REGION=us-east-2
+MYIP=$(curl -fsSL https://checkip.amazonaws.com)
+aws ec2 authorize-security-group-ingress \
+  --group-id <non-prod-sg-id> \
+  --protocol tcp \
+  --port 5432 \
+  --cidr ${MYIP}/32
+```
+
+### 2) Connect as the RDS master user
+
+```bash
+psql "host=<non-prod-endpoint> port=5432 user=<admin_user> dbname=postgres sslmode=require"
+```
+
+### 3) Create roles and set passwords
+
+```sql
+CREATE ROLE mnemosys_sandbox_admin LOGIN;
+CREATE ROLE mnemosys_sandbox_user LOGIN;
+CREATE ROLE mnemosys_dev_admin LOGIN;
+CREATE ROLE mnemosys_dev_user LOGIN;
+CREATE ROLE mnemosys_test_admin LOGIN;
+CREATE ROLE mnemosys_test_user LOGIN;
+
+\password mnemosys_sandbox_admin
+\password mnemosys_sandbox_user
+\password mnemosys_dev_admin
+\password mnemosys_dev_user
+\password mnemosys_test_admin
+\password mnemosys_test_user
+```
+
+### 4) Create databases and isolate access
+
+Run each `CREATE DATABASE` independently; if it already exists, skip it.
+
+```sql
+CREATE DATABASE mnemosys_sandbox OWNER mnemosys_sandbox_admin;
+CREATE DATABASE mnemosys_dev OWNER mnemosys_dev_admin;
+CREATE DATABASE mnemosys_test OWNER mnemosys_test_admin;
+
+GRANT ALL PRIVILEGES ON DATABASE mnemosys_sandbox TO mnemosys_sandbox_admin;
+GRANT CONNECT ON DATABASE mnemosys_sandbox TO mnemosys_sandbox_user;
+
+GRANT ALL PRIVILEGES ON DATABASE mnemosys_dev TO mnemosys_dev_admin;
+GRANT CONNECT ON DATABASE mnemosys_dev TO mnemosys_dev_user;
+
+GRANT ALL PRIVILEGES ON DATABASE mnemosys_test TO mnemosys_test_admin;
+GRANT CONNECT ON DATABASE mnemosys_test TO mnemosys_test_user;
+
+REVOKE CONNECT ON DATABASE mnemosys_dev FROM mnemosys_sandbox_admin, mnemosys_sandbox_user, mnemosys_test_admin, mnemosys_test_user;
+REVOKE CONNECT ON DATABASE mnemosys_sandbox FROM mnemosys_dev_admin, mnemosys_dev_user, mnemosys_test_admin, mnemosys_test_user;
+REVOKE CONNECT ON DATABASE mnemosys_test FROM mnemosys_sandbox_admin, mnemosys_sandbox_user, mnemosys_dev_admin, mnemosys_dev_user;
+```
+
+### 5) Grant schema access (sandbox/dev/test)
+
+Run each block while connected to the target database as its admin role.
+
+Sandbox:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS mnemosys AUTHORIZATION mnemosys_sandbox_admin;
+GRANT USAGE ON SCHEMA mnemosys TO mnemosys_sandbox_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA mnemosys TO mnemosys_sandbox_user;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA mnemosys TO mnemosys_sandbox_user;
+ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_sandbox_admin IN SCHEMA mnemosys
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO mnemosys_sandbox_user;
+ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_sandbox_admin IN SCHEMA mnemosys
+    GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO mnemosys_sandbox_user;
+```
+
+Development:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS mnemosys AUTHORIZATION mnemosys_dev_admin;
+GRANT USAGE ON SCHEMA mnemosys TO mnemosys_dev_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA mnemosys TO mnemosys_dev_user;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA mnemosys TO mnemosys_dev_user;
+ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_dev_admin IN SCHEMA mnemosys
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO mnemosys_dev_user;
+ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_dev_admin IN SCHEMA mnemosys
+    GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO mnemosys_dev_user;
+```
+
+Test:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS mnemosys AUTHORIZATION mnemosys_test_admin;
+GRANT USAGE ON SCHEMA mnemosys TO mnemosys_test_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA mnemosys TO mnemosys_test_user;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA mnemosys TO mnemosys_test_user;
+ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_test_admin IN SCHEMA mnemosys
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO mnemosys_test_user;
+ALTER DEFAULT PRIVILEGES FOR ROLE mnemosys_test_admin IN SCHEMA mnemosys
+    GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO mnemosys_test_user;
+```
+
+### 6) Local environment configuration (sandbox only)
+
+Local `.env` uses sandbox credentials only (no dev/test/prod secrets). Provide shared connection details plus both admin and user credentials:
+
+```bash
+MNEMOSYS_DB_HOST=<non-prod-endpoint>
+MNEMOSYS_DB_PORT=5432
+MNEMOSYS_DB_DRIVERNAME=postgresql
+MNEMOSYS_DB_DATABASE=mnemosys_sandbox
+MNEMOSYS_DB_SSLMODE=require
+MNEMOSYS_DB_USERNAME=mnemosys_sandbox_user
+MNEMOSYS_DB_PASSWORD=<sandbox-user-password>
+
+MNEMOSYS_DB_ADMIN_USERNAME=mnemosys_sandbox_admin
+MNEMOSYS_DB_ADMIN_PASSWORD=<sandbox-admin-password>
+
+MNEMOSYS_ENV=sandbox
+MNEMOSYS_DB_SCHEMA=mnemosys
+```
+
+Notes:
+- `MNEMOSYS_DB_ADMIN_*` inherits host/port/driver/database/sslmode from `MNEMOSYS_DB_*` unless overridden.
+
+## Production Setup (Dedicated RDS)
+
+Repeat the same steps on the production RDS instance using:
+
+- `mnemosys_prod` database
+- `mnemosys_prod_admin` and `mnemosys_prod_user` roles
+
+Local environments must never store production credentials.
+
+## Bootstrap Exit (Lockdown)
+
+When automated deployment updates `mnemosys_dev` and restarts the REST API,
+bootstrap ends and the non-prod RDS instance must be locked down. See the
+bootstrap exit checklist in `docs/policies/aws-db-bootstrap-constraints.md`.

--- a/docs/aws/nonprod-rest-api-deploy-plan.md
+++ b/docs/aws/nonprod-rest-api-deploy-plan.md
@@ -1,0 +1,627 @@
+# AWS Nonprod REST API Deployment Plan (Bootstrap v0.1)
+
+**Date**: 2026-01-04
+**Status**: Completed (bootstrap + parity complete)
+**Last verified**: 2026-01-12
+
+## Completion Summary
+
+- Bootstrap and parity steps are complete.
+- This plan remains as historical reference for future rebuilds.
+
+## Table of Contents
+- [Completion Summary](#completion-summary)
+- [Overview](#overview)
+- [Scope](#scope)
+- [Non-Goals](#non-goals)
+- [Assumptions (Locked for v0.1)](#assumptions-locked-for-v01)
+- [Architecture Summary (Minimal)](#architecture-summary-minimal)
+- [Secrets and Parameter Naming (SSM)](#secrets-and-parameter-naming-ssm)
+- [Migration Path to Durable Infrastructure (Explicit)](#migration-path-to-durable-infrastructure-explicit)
+- [Runtime Contract (Migration Gate)](#runtime-contract-migration-gate)
+- [Implementation Plan (Step-by-Step)](#implementation-plan-step-by-step)
+  - [Step 0: Repository additions (local)](#step-0-repository-additions-local)
+  - [Step 1: AWS bootstrap variables](#step-1-aws-bootstrap-variables)
+  - [Step 2: Security groups](#step-2-security-groups)
+  - [Step 3: ECR and logs](#step-3-ecr-and-logs)
+  - [Step 4: IAM roles](#step-4-iam-roles)
+  - [Step 5: ECS cluster + ALB](#step-5-ecs-cluster-alb)
+  - [Step 6: ECS task definitions and services](#step-6-ecs-task-definitions-and-services)
+  - [Step 7: GitHub Actions deployment](#step-7-github-actions-deployment)
+  - [Step 8: Validation](#step-8-validation)
+- [Implementation Status (Verified 2026-01-12)](#implementation-status-verified-2026-01-12)
+- [Test/Production Parity Plan (Consolidated)](#testproduction-parity-plan-consolidated)
+- [Known Issues](#known-issues)
+- [Open Questions (Deferred)](#open-questions-deferred)
+- [Bootstrap Outputs (Verified 2026-01-12)](#bootstrap-outputs-verified-2026-01-12)
+
+## Overview
+
+This plan defines the AWS bootstrap steps and GitHub Actions automation needed to deploy
+the MNEMOSYS REST API to **development** and **test** environments. It follows the
+branch-to-environment mapping defined in
+https://github.com/wphillipmoore/standards-and-conventions/blob/main/docs/code-management/branching-and-deployment.md
+and the database bootstrap constraints in `docs/aws/database-environment-setup.md`.
+
+The initial implementation uses **minimal AWS infrastructure** (default VPC, HTTP-only ALB)
+to reduce bootstrap friction, while preserving a clean migration path to a dedicated VPC
+and TLS-based routing later.
+
+This plan now consolidates the test/production parity work from
+`docs/aws/test-prod-db-parity-plan.md` to prevent
+rework in deployment automation.
+
+## Scope
+
+- Nonprod AWS infrastructure for REST API deployment (development + test).
+- AWS CLI-first provisioning and updates.
+- GitHub Actions automation for deploys on `develop` and `release`.
+- Runtime contract for migration gate + API startup.
+- Test/production parity definition and rollout sequencing (RDS + REST API).
+
+## Non-Goals
+
+- Production deployment (main branch).
+- Multi-account or multi-cloud configuration.
+- Full Infrastructure-as-Code migration (Terraform/CDK/CloudFormation).
+- TLS/ACM and custom DNS (deferred to durable phase).
+
+## Assumptions (Locked for v0.1)
+
+- REST API runtime: **FastAPI** on **ECS Fargate**.
+- Nonprod AWS account: single account with `mnemosys-admin` IAM user.
+- Region: `us-east-2`.
+- Nonprod RDS is already provisioned per bootstrap doc; API needs only network access + creds.
+- Sandbox is local-only and does not deploy.
+
+## Architecture Summary (Minimal)
+
+- **ECS Fargate**: one cluster, two services (`mnemosys-dev-api`, `mnemosys-test-api`).
+- **ECR**: one repository (`mnemosys-core`) for container images.
+- **ALB**: single load balancer with two listeners.
+  - Port 80 -> dev target group
+  - Port 8080 -> test target group
+  - Rationale: ALB does not rewrite paths, so port-based routing avoids prefix rewrites.
+- **Security Groups**:
+  - ALB SG: inbound 80 from internet; outbound to ECS SG.
+  - ECS SG: inbound 8000 from ALB SG; outbound 5432 to RDS SG.
+- **IAM Roles**:
+  - ECS task execution role (ECR pull + CloudWatch logs).
+  - ECS task role (read secrets).
+  - GitHub Actions OIDC role for deploys.
+- **Logging**: CloudWatch log groups per environment (`/mnemosys/dev/api`, `/mnemosys/test/api`).
+- **Secrets**: SSM Parameter Store (SecureString) for DB credentials.
+
+## Secrets and Parameter Naming (SSM)
+
+Parameters are stored under `/mnemosys/<environment>/` using SecureString values.
+Environment values are `development` and `test` (log group names use `dev`/`test` shorthand for consistency with ECS service names).
+
+Required parameters per environment:
+
+- `/mnemosys/<environment>/db/drivername` (e.g., `postgresql`)
+- `/mnemosys/<environment>/db/username`
+- `/mnemosys/<environment>/db/password`
+- `/mnemosys/<environment>/db/host`
+- `/mnemosys/<environment>/db/port` (string)
+- `/mnemosys/<environment>/db/database` (e.g., `mnemosys_dev` or `mnemosys_test`)
+- `/mnemosys/<environment>/db/sslmode` (e.g., `require`)
+- `/mnemosys/<environment>/db_admin/username`
+- `/mnemosys/<environment>/db_admin/password`
+
+Example parameter creation:
+
+```bash
+aws ssm put-parameter \
+  --name /mnemosys/development/db/host \
+  --type SecureString \
+  --value <rds-endpoint> \
+  --overwrite
+```
+
+## Migration Path to Durable Infrastructure (Explicit)
+
+Minimal bootstrap must not block a dedicated VPC/TLS setup. To preserve the path:
+
+- Use explicit, unique resource names (avoid implicit defaults).
+- Keep ECS task definitions and services portable across subnets.
+- Treat ALB + ECS + SGs as replaceable layers.
+- Keep all sensitive values in Secrets Manager/SSM from day one.
+- Avoid hardcoding VPC IDs or subnet IDs in code; use variables in CLI scripts.
+
+See [Test/Production Parity Plan (Consolidated)](#testproduction-parity-plan-consolidated)
+for the test/production database parity and RDS recreation plan.
+
+## Runtime Contract (Migration Gate)
+
+Every container start must execute the migration gate before serving traffic:
+
+1. `python alembic/runner.py upgrade` (uses `MNEMOSYS_DB_ADMIN_*` with fallback).
+2. Start `uvicorn` only after upgrade runner exits successfully.
+
+This enforces the behavior documented in
+https://github.com/wphillipmoore/mnemosys-core/blob/main/docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md.
+
+## Implementation Plan (Step-by-Step)
+
+### Step 0: Repository additions (local)
+
+- Add `Dockerfile` for FastAPI + uvicorn.
+- Add `scripts/runtime/entrypoint.sh` to run migration runner then start API.
+- Add `src/mnemosys_core/api/runtime.py` factory for uvicorn `--factory` usage.
+- Add `infra/ecs/task-def-template.json` plus render helper at `scripts/deploy/render_task_definition.py`.
+- Add IAM template render helper at `scripts/deploy/render_iam_templates.py`.
+- Add AWS IAM policy JSON files under `infra/iam/`.
+- Add `.github/workflows/deploy-nonprod.yml` for `develop` and `release`.
+
+### Step 1: AWS bootstrap variables
+
+```bash
+export AWS_PROFILE=mnemosys-admin
+export AWS_REGION=us-east-2
+```
+
+Use default VPC for v0.1 bootstrap:
+
+```bash
+VPC_ID=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query "Vpcs[0].VpcId" --output text)
+SUBNET_IDS=$(aws ec2 describe-subnets --filters Name=vpc-id,Values=$VPC_ID --query "Subnets[].SubnetId" --output text)
+```
+
+### Step 2: Security groups
+
+Create ALB and ECS security groups. Allow ALB -> ECS and ECS -> RDS:
+
+```bash
+ALB_SG_ID=$(aws ec2 create-security-group \
+  --group-name mnemosys-nonprod-alb-sg \
+  --description "ALB SG for mnemosys nonprod" \
+  --vpc-id "$VPC_ID" --query "GroupId" --output text)
+
+ECS_SG_ID=$(aws ec2 create-security-group \
+  --group-name mnemosys-nonprod-ecs-sg \
+  --description "ECS SG for mnemosys nonprod" \
+  --vpc-id "$VPC_ID" --query "GroupId" --output text)
+
+aws ec2 authorize-security-group-ingress \
+  --group-id "$ALB_SG_ID" --protocol tcp --port 80 --cidr 0.0.0.0/0
+
+aws ec2 authorize-security-group-ingress \
+  --group-id "$ALB_SG_ID" --protocol tcp --port 8080 --cidr 0.0.0.0/0
+
+aws ec2 authorize-security-group-ingress \
+  --group-id "$ECS_SG_ID" --protocol tcp --port 8000 --source-group "$ALB_SG_ID"
+```
+
+RDS SG rule (if RDS is already provisioned):
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --group-id <rds-sg-id> --protocol tcp --port 5432 --source-group "$ECS_SG_ID"
+```
+
+### Step 3: ECR and logs
+
+```bash
+aws ecr create-repository --repository-name mnemosys-core
+aws logs create-log-group --log-group-name /mnemosys/dev/api
+aws logs create-log-group --log-group-name /mnemosys/test/api
+```
+
+### Step 4: IAM roles
+
+Create IAM roles for:
+- ECS execution role (ECR + logs).
+- ECS task role (read DB secrets).
+- GitHub Actions OIDC role (deploy automation).
+
+These use JSON policy files stored in `infra/iam/` and require placeholder substitution:
+
+- `infra/iam/ecs-task-exec-trust.json`
+- `infra/iam/ecs-task-trust.json`
+- `infra/iam/ecs-task-secrets-policy.json`
+- `infra/iam/gha-deploy-role-trust.json`
+- `infra/iam/gha-deploy-policy.json`
+
+Render the templates into a temporary directory:
+
+```bash
+python scripts/deploy/render_iam_templates.py \
+  --output-dir /tmp/mnemosys-iam \
+  --aws-account-id <account-id> \
+  --aws-region us-east-2 \
+  --github-org <github-org> \
+  --github-repo <github-repo>
+```
+
+Create the GitHub OIDC provider (required for Actions):
+
+```bash
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com \
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+```
+
+Note: verify the current thumbprint from GitHub if AWS rejects the provider creation.
+
+Create roles and policies using rendered files:
+
+```bash
+aws iam create-role \
+  --role-name mnemosys-ecs-task-exec \
+  --assume-role-policy-document file:///tmp/mnemosys-iam/ecs-task-exec-trust.json
+
+aws iam attach-role-policy \
+  --role-name mnemosys-ecs-task-exec \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+aws iam create-role \
+  --role-name mnemosys-ecs-task \
+  --assume-role-policy-document file:///tmp/mnemosys-iam/ecs-task-trust.json
+
+aws iam put-role-policy \
+  --role-name mnemosys-ecs-task \
+  --policy-name mnemosys-ecs-task-secrets \
+  --policy-document file:///tmp/mnemosys-iam/ecs-task-secrets-policy.json
+
+# ECS execution role also needs SSM access to fetch secrets at task startup.
+aws iam put-role-policy \
+  --role-name mnemosys-ecs-task-exec \
+  --policy-name mnemosys-ecs-task-exec-ssm \
+  --policy-document file:///tmp/mnemosys-iam/ecs-task-secrets-policy.json
+
+aws iam create-role \
+  --role-name mnemosys-gha-deploy \
+  --assume-role-policy-document file:///tmp/mnemosys-iam/gha-deploy-role-trust.json
+
+aws iam put-role-policy \
+  --role-name mnemosys-gha-deploy \
+  --policy-name mnemosys-gha-deploy-policy \
+  --policy-document file:///tmp/mnemosys-iam/gha-deploy-policy.json
+```
+
+### Step 5: ECS cluster + ALB
+
+```bash
+aws ecs create-cluster --cluster-name mnemosys-nonprod
+
+ALB_ARN=$(aws elbv2 create-load-balancer \
+  --name mnemosys-nonprod-alb \
+  --subnets $SUBNET_IDS \
+  --security-groups "$ALB_SG_ID" \
+  --query "LoadBalancers[0].LoadBalancerArn" --output text)
+
+DEV_TG_ARN=$(aws elbv2 create-target-group \
+  --name mnemosys-dev-tg --protocol HTTP --port 8000 \
+  --vpc-id "$VPC_ID" --health-check-path /health/ \
+  --target-type ip \
+  --query "TargetGroups[0].TargetGroupArn" --output text)
+
+TEST_TG_ARN=$(aws elbv2 create-target-group \
+  --name mnemosys-test-tg --protocol HTTP --port 8000 \
+  --vpc-id "$VPC_ID" --health-check-path /health/ \
+  --target-type ip \
+  --query "TargetGroups[0].TargetGroupArn" --output text)
+
+DEV_LISTENER_ARN=$(aws elbv2 create-listener \
+  --load-balancer-arn "$ALB_ARN" --protocol HTTP --port 80 \
+  --default-actions Type=forward,TargetGroupArn="$DEV_TG_ARN" \
+  --query "Listeners[0].ListenerArn" --output text)
+
+TEST_LISTENER_ARN=$(aws elbv2 create-listener \
+  --load-balancer-arn "$ALB_ARN" --protocol HTTP --port 8080 \
+  --default-actions Type=forward,TargetGroupArn="$TEST_TG_ARN" \
+  --query "Listeners[0].ListenerArn" --output text)
+```
+
+### Step 6: ECS task definitions and services
+
+- Render `infra/ecs/task-def-template.json` with `scripts/deploy/render_task_definition.py`.
+- Set `MNEMOSYS_ENV` to `development` or `test`.
+- Inject `MNEMOSYS_DB_*` and `MNEMOSYS_DB_ADMIN_*` from SSM parameters.
+- Entrypoint runs migration gate then starts uvicorn.
+
+Register task definitions and create services:
+
+```bash
+python scripts/deploy/render_task_definition.py \
+  --template infra/ecs/task-def-template.json \
+  --output /tmp/task-def-dev.json \
+  --environment development \
+  --image-uri <image-uri> \
+  --execution-role-arn <ecs-task-exec-role-arn> \
+  --task-role-arn <ecs-task-role-arn> \
+  --log-group /mnemosys/dev/api \
+  --aws-region us-east-2
+
+aws ecs register-task-definition --cli-input-json file:///tmp/task-def-dev.json
+
+python scripts/deploy/render_task_definition.py \
+  --template infra/ecs/task-def-template.json \
+  --output /tmp/task-def-test.json \
+  --environment test \
+  --image-uri <image-uri> \
+  --execution-role-arn <ecs-task-exec-role-arn> \
+  --task-role-arn <ecs-task-role-arn> \
+  --log-group /mnemosys/test/api \
+  --aws-region us-east-2
+
+aws ecs register-task-definition --cli-input-json file:///tmp/task-def-test.json
+
+aws ecs create-service \
+  --cluster mnemosys-nonprod \
+  --service-name mnemosys-dev-api \
+  --task-definition mnemosys-dev-api \
+  --desired-count 1 --launch-type FARGATE \
+  --health-check-grace-period-seconds 120 \
+  --network-configuration "awsvpcConfiguration={subnets=[...],securityGroups=[$ECS_SG_ID],assignPublicIp=ENABLED}" \
+  --load-balancers targetGroupArn=$DEV_TG_ARN,containerName=mnemosys-api,containerPort=8000
+
+aws ecs create-service \
+  --cluster mnemosys-nonprod \
+  --service-name mnemosys-test-api \
+  --task-definition mnemosys-test-api \
+  --desired-count 1 --launch-type FARGATE \
+  --health-check-grace-period-seconds 120 \
+  --network-configuration "awsvpcConfiguration={subnets=[...],securityGroups=[$ECS_SG_ID],assignPublicIp=ENABLED}" \
+  --load-balancers targetGroupArn=$TEST_TG_ARN,containerName=mnemosys-api,containerPort=8000
+```
+
+### Step 7: GitHub Actions deployment
+
+Deploy on branch merges:
+- `develop` -> development service
+- `release` -> test service
+
+Required GitHub Actions repository variables:
+
+- `AWS_ACCOUNT_ID`
+- `AWS_OIDC_ROLE_ARN` (role ARN for `mnemosys-gha-deploy`)
+
+Workflow actions:
+1. Build container image.
+2. Push to ECR.
+3. Render new task definition with updated image tag.
+4. Register task definition.
+5. Update ECS service and wait for stability.
+
+Use GitHub OIDC for AWS auth (no static keys).
+
+### Step 8: Validation
+
+- Hit `/health` on ALB default path for development.
+- Hit `/health` on the test listener (port 8080).
+- Confirm ECS tasks log migration runner output.
+- Confirm alembic gate applies new revisions before app start.
+
+Example:
+
+```bash
+curl -fsSL http://<alb-dns>/health/
+curl -fsSL http://<alb-dns>:8080/health/
+```
+
+## Implementation Status (Verified 2026-01-12)
+
+- Parity steps completed; plan closed.
+- Step 0: Complete. `Dockerfile`, `scripts/runtime/entrypoint.sh`,
+  `src/mnemosys_core/api/runtime.py`, `infra/ecs/task-def-template.json`,
+  `scripts/deploy/render_task_definition.py`, `scripts/deploy/render_iam_templates.py`,
+  `infra/iam/*.json`, and `.github/workflows/deploy-nonprod.yml` exist.
+- Step 1: Complete. Default VPC `vpc-06f003b77e593c99a` with subnets
+  `subnet-0c174c9ad03ad6808`, `subnet-07ebe0f6e86eb955b`,
+  `subnet-017aaa23437259fa2`.
+- Step 2: Complete. ALB SG `sg-0899f0b2207153896` allows 80/8080 from 0.0.0.0/0.
+  ECS SG `sg-069f915c6fc98b0a6` allows 8000 from ALB SG.
+  RDS SG `sg-0463c511b48bcbef5` allows 5432 from ECS SG (plus user IP).
+- Step 3: Complete. ECR repo `mnemosys-core` exists. Log groups exist at
+  `/mnemosys/dev/api` and `/mnemosys/test/api`.
+- Step 4: Complete. IAM roles exist (`mnemosys-ecs-task-exec`, `mnemosys-ecs-task`,
+  `mnemosys-gha-deploy`) and include SSM read + KMS decrypt. GitHub OIDC provider exists.
+- Step 5: Complete. ECS cluster `mnemosys-nonprod` active. ALB listeners:
+  80 -> dev target group, 8080 -> test target group.
+- Step 6: Complete. Services running with one task each.
+  Dev task definition `mnemosys-development-api:22` uses ECR tag
+  `0aa05c9dfd551f34cc99d09c1137c856783ea148`.
+  Test task definition `mnemosys-test-api:1` uses ECR tag `bootstrap-20260104104343`
+  (release pipeline not updated since bootstrap).
+- Step 7: Complete in repo and IAM. Workflow exists at
+  `.github/workflows/deploy-nonprod.yml`. OIDC role `mnemosys-gha-deploy` exists.
+  Repository variables (`AWS_ACCOUNT_ID`, `AWS_OIDC_ROLE_ARN`) not verified here.
+- Step 8: Complete. `/health/` returns 200 for both listeners.
+- Test/Dev DB state: SSM parameters exist for both environments and currently
+  point to the same RDS host with separate databases (`mnemosys_dev`, `mnemosys_test`).
+
+## Test/Production Parity Plan (Consolidated)
+
+This section replaces `docs/aws/test-prod-db-parity-plan.md`.
+Do not execute test/prod parity changes until the baseline decisions are explicit.
+
+### Baseline Decisions (Locked 2026-01-12)
+
+RDS (test):
+
+- Dedicated test instance: required (no longer share dev host).
+- Instance identifier: `mnemosys-test-postgres`.
+- Engine/version: Postgres 16.11 (match current).
+- Instance class: `db.t4g.large` (initial; tuning allowed later).
+- Storage: `gp3` 200 GB, 3000 IOPS, 125 MB/s (initial; tuning allowed later).
+- Multi-AZ: **true** (required for production-intent redundancy).
+- Backup retention: 35 days (initial; adjust later).
+- Deletion protection: true.
+- Performance Insights: enabled, 7-day retention (initial; adjust later).
+- Parameter group: `default.postgres16` (initial; custom group later if needed).
+- Public accessibility: **true for bootstrap** (explicit parity exception until
+  private subnets/VPC migration exists).
+- Subnet group: default VPC subnets (explicit parity exception).
+
+REST API (test):
+
+- Desired count: 2 (minimum redundancy).
+- Autoscaling: off (explicit parity exception during bootstrap).
+- Deployment configuration: minimum healthy percent 100, maximum percent 200.
+- Deployment circuit breaker: enabled with rollback.
+- Health check grace period: 180s.
+- Task sizing: CPU 256, memory 512 (explicit parity exception during bootstrap).
+
+1. Inventory current RDS configuration (already captured in Bootstrap Outputs) and
+   document the delta against the locked baseline above.
+2. Inventory current REST API configuration (desired count, autoscaling, deployment
+   configuration, task sizing, health checks).
+3. Recreate the test database instance (`mnemosys-test-postgres`) to match the locked
+   baseline, then update `/mnemosys/test/db/*` parameters (and `/mnemosys/test/db_admin/*`
+   if credentials are rotated).
+4. Update test ECS service to match the REST API baseline (desired count, deployment
+   configuration, circuit breaker, health check grace period, task sizing).
+5. Validate release pipeline behavior (release -> test), ensure migration gate runs,
+   and confirm health checks succeed post-deploy.
+6. Document parity rules and drift exceptions explicitly in this plan.
+
+Step 3 execution (test RDS rebuild):
+
+If rotating admin credentials, update the `/mnemosys/test/db_admin/*` parameters
+before creating the new instance.
+
+```bash
+TEST_ADMIN_USERNAME=$(aws ssm get-parameter \
+  --name /mnemosys/test/db_admin/username \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text)
+
+TEST_ADMIN_PASSWORD=$(aws ssm get-parameter \
+  --name /mnemosys/test/db_admin/password \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text)
+
+aws rds create-db-instance \
+  --db-instance-identifier mnemosys-test-postgres \
+  --db-instance-class db.t4g.large \
+  --engine postgres \
+  --engine-version 16.11 \
+  --db-name mnemosys_test \
+  --master-username "${TEST_ADMIN_USERNAME}" \
+  --master-user-password "${TEST_ADMIN_PASSWORD}" \
+  --allocated-storage 200 \
+  --storage-type gp3 \
+  --iops 3000 \
+  --storage-throughput 125 \
+  --backup-retention-period 35 \
+  --multi-az \
+  --publicly-accessible \
+  --storage-encrypted \
+  --deletion-protection \
+  --enable-performance-insights \
+  --performance-insights-retention-period 7 \
+  --db-subnet-group-name default-vpc-06f003b77e593c99a \
+  --vpc-security-group-ids sg-0463c511b48bcbef5
+
+aws rds wait db-instance-available \
+  --db-instance-identifier mnemosys-test-postgres
+
+TEST_ENDPOINT=$(aws rds describe-db-instances \
+  --db-instance-identifier mnemosys-test-postgres \
+  --query "DBInstances[0].Endpoint.Address" \
+  --output text)
+
+aws ssm put-parameter \
+  --name /mnemosys/test/db/host \
+  --type SecureString \
+  --value "${TEST_ENDPOINT}" \
+  --overwrite
+
+aws ssm put-parameter \
+  --name /mnemosys/test/db/port \
+  --type SecureString \
+  --value "5432" \
+  --overwrite
+
+aws ssm put-parameter \
+  --name /mnemosys/test/db/database \
+  --type SecureString \
+  --value "mnemosys_test" \
+  --overwrite
+
+aws ecs update-service \
+  --cluster mnemosys-nonprod \
+  --service mnemosys-test-api \
+  --force-new-deployment
+
+aws ecs wait services-stable \
+  --cluster mnemosys-nonprod \
+  --services mnemosys-test-api
+```
+
+Optional cleanup: drop the `mnemosys_test` database from the shared dev instance
+once the new test instance is live to prevent accidental use.
+
+Step 4 execution (test):
+
+```bash
+aws ecs update-service \
+  --cluster mnemosys-nonprod \
+  --service mnemosys-test-api \
+  --desired-count 2 \
+  --health-check-grace-period-seconds 180 \
+  --deployment-configuration "minimumHealthyPercent=100,maximumPercent=200,deploymentCircuitBreaker={enable=true,rollback=true}"
+
+aws ecs wait services-stable \
+  --cluster mnemosys-nonprod \
+  --services mnemosys-test-api
+```
+
+If task sizing changes later, re-render and register a new task definition before
+running the `update-service` step.
+
+Autoscaling remains off during bootstrap; confirm no scalable target exists:
+
+```bash
+aws application-autoscaling describe-scalable-targets \
+  --service-namespace ecs \
+  --resource-ids service/mnemosys-nonprod/mnemosys-test-api
+```
+
+## Known Issues
+
+- `brew install --cask docker` can time out during Docker Desktop download; current Docker 20.10.12 is sufficient for nonprod builds.
+- Retry the install locally if a Desktop upgrade is required: `brew install --cask docker`.
+
+## Open Questions (Deferred)
+
+- When to switch to a dedicated VPC and private subnets?
+- When to add TLS and real subdomains for dev/test?
+- Do we want separate ALBs for dev/test or keep shared until prod?
+- Should migration gate run in container entrypoint or init task?
+
+## Bootstrap Outputs (Verified 2026-01-12)
+
+Captured from the initial bootstrap run (update if re-provisioned):
+
+- AWS account: `959713283130`
+- Region: `us-east-2`
+- Default VPC: `vpc-06f003b77e593c99a`
+- Subnets: `subnet-0c174c9ad03ad6808`, `subnet-07ebe0f6e86eb955b`, `subnet-017aaa23437259fa2`
+- RDS instance: `mnemosys-postgres`
+- RDS endpoint: `mnemosys-postgres.c3uamoeq6wst.us-east-2.rds.amazonaws.com`
+- RDS SG: `sg-0463c511b48bcbef5`
+- RDS configuration: `db.t4g.large`, Postgres `16.11`, `gp3` 200 GB, 3000 IOPS,
+  Multi-AZ `false`, backup retention `7`, deletion protection `true`,
+  performance insights `enabled`.
+- Dev/Test DB names: `mnemosys_dev`, `mnemosys_test` (shared RDS host).
+- ALB name: `mnemosys-nonprod-alb`
+- ALB DNS: `mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com`
+- ALB SG: `sg-0899f0b2207153896`
+- ECS SG: `sg-069f915c6fc98b0a6`
+- ECS cluster: `mnemosys-nonprod`
+- ECR repo URI: `959713283130.dkr.ecr.us-east-2.amazonaws.com/mnemosys-core`
+- Target groups:
+  - dev: `arn:aws:elasticloadbalancing:us-east-2:959713283130:targetgroup/mnemosys-dev-tg/a9cebb5223d19b3a`
+  - test: `arn:aws:elasticloadbalancing:us-east-2:959713283130:targetgroup/mnemosys-test-tg/df967036165866c3`
+- Listeners:
+  - dev: port 80 -> `arn:aws:elasticloadbalancing:us-east-2:959713283130:listener/app/mnemosys-nonprod-alb/ba78c0d6da6303b6/58c3cce7af769176`
+  - test: port 8080 -> `arn:aws:elasticloadbalancing:us-east-2:959713283130:listener/app/mnemosys-nonprod-alb/ba78c0d6da6303b6/ad630da2ac235c61`
+- Services:
+  - dev: `mnemosys-dev-api`
+  - test: `mnemosys-test-api`

--- a/docs/aws/test-prod-db-parity-plan.md
+++ b/docs/aws/test-prod-db-parity-plan.md
@@ -1,0 +1,125 @@
+# Test/Production Environment Parity Plan (RDS + REST API)
+
+**Status:** Completed (merged into `docs/aws/nonprod-rest-api-deploy-plan.md`)
+
+This plan is consolidated into the nonprod deployment plan. Do not execute it
+independently; use the consolidated plan instead.
+
+## Table of Contents
+- [Context](#context)
+- [Goals](#goals)
+- [Non-Goals](#non-goals)
+- [Invariants](#invariants)
+- [Current State (Assumed)](#current-state-assumed)
+- [Target State](#target-state)
+- [Plan (Step-by-Step)](#plan-step-by-step)
+- [Validation](#validation)
+- [Risks](#risks)
+- [Open Questions](#open-questions)
+
+## Context
+
+The test environment must be a near-identical proxy for production. That requires
+both the database and the REST API to run on the same infrastructure tier with
+minimal configuration drift. To achieve this, we will promote the managed Postgres
+instance used for development into a production-tier configuration and use that
+pattern for the test database (release branch deployments). In parallel, the test
+REST API service must run with production-like resiliency settings so the API and
+database are evaluated together as a matched pair.
+
+This plan builds on:
+- `docs/aws/nonprod-rest-api-deploy-plan.md`
+- `docs/aws/database-environment-setup.md`
+
+## Goals
+
+- Align test and production database infrastructure tiers.
+- Align test and production REST API infrastructure tiers and resiliency settings.
+- Document the production-grade AWS RDS and REST API configuration by applying it to test.
+- Keep dev/test updates strictly pipeline-driven (no local credentials).
+- Preserve "rebuild from scratch" and migration gate behavior.
+
+## Non-Goals
+
+- Full production cutover (main branch) and public-facing rollout.
+- Multi-account or multi-region database strategy.
+- Database sharding, read replicas, or cross-region replication.
+
+## Invariants
+
+- Test and production use the same engine version, parameter group, instance class,
+  storage type, encryption, and backup policies.
+- Test and production REST API services use the same deployment topology,
+  health checks, scaling configuration, and failure handling defaults.
+- Release branch drives test deployments; developers do not hold test credentials.
+- Migration gate remains the only automated schema change path.
+- Any drift between test and production must be intentional, documented, and minimal.
+- Test database data is disposable during this proof-of-concept phase.
+
+## Current State (Assumed)
+
+- Nonprod RDS exists and is used by development/test deployments.
+- Development database is on a non-production tier configuration.
+- Test REST API is deployed but not configured for production-grade resiliency.
+- Test database credentials are stored only in AWS (SSM/Secrets), not locally.
+
+## Target State
+
+- Test database runs on production-tier RDS configuration.
+- Test REST API runs with production-grade resiliency configuration.
+- Configuration parity with production is explicit and enforced.
+- Development remains isolated from test (no shared credentials; no direct access).
+
+## Plan (Step-by-Step)
+
+1. Inventory current RDS configuration used by development/test:
+   - Engine version, instance class, storage type, IOPS, encryption.
+   - Parameter group, maintenance window, backup retention.
+   - Security groups, subnet group, VPC placement.
+2. Inventory current REST API configuration used by development/test:
+   - ECS service desired count, autoscaling rules, health checks.
+   - Deployment strategy, circuit breaker settings, and timeouts.
+   - Task sizing, CPU/memory, and networking configuration.
+3. Define the production-tier baseline:
+   - Instance class and storage class sized for production.
+   - Multi-AZ, backup retention, deletion protection, performance insights.
+   - Parameter group settings required for production parity.
+4. Define the production-tier REST API baseline:
+   - Desired count and autoscaling targets for resiliency.
+   - Health check configuration (ALB + container) and timeouts.
+   - Deployment settings (minimum healthy percent, max percent).
+5. Destroy and recreate the test database as a clean production-tier instance:
+   - No data preservation required in the current proof-of-concept phase.
+   - Apply instance class, storage, and parameter group changes at creation time.
+   - Enforce backups, encryption, monitoring, deletion protection.
+6. Update AWS secrets/SSM parameters for the test environment:
+   - `/mnemosys/test/db/host`, `/mnemosys/test/db/port`, etc.
+   - Confirm admin credentials are present and rotate if required.
+7. Update REST API service configuration for test to match production baseline:
+   - Apply scaling, health check, deployment, and resiliency settings.
+   - Confirm task definitions and runtime configuration are aligned with prod.
+8. Validate pipeline behavior:
+   - Merge `develop` -> `release` and confirm the migration gate runs against the
+     updated test database and succeeds.
+   - Confirm application health checks succeed post-deploy.
+9. Document the production-grade RDS and REST API configuration and parity rules.
+
+## Validation
+
+- Release pipeline deploys to test without manual database access.
+- Alembic migration gate applies cleanly and logs expected output.
+- RDS configuration matches the production-tier baseline.
+- REST API service configuration matches the production-tier baseline.
+
+## Risks
+
+- Misconfigured parameter group or storage settings can cause downtime.
+- REST API resiliency drift can hide production-only failure modes.
+- Drift between test and production if parity rules are not enforced in docs.
+- Instance recreation changes endpoints and requires secrets updates.
+
+## Open Questions
+
+- Is Multi-AZ required for test (to mirror production) or optional for cost?
+- What are the exact production-tier parameters (instance class, storage size, IOPS)?
+- What are the target REST API resiliency parameters (desired count, autoscaling thresholds)?

--- a/docs/operations/2026-01-12-18-31-nonprod-parity-ops.md
+++ b/docs/operations/2026-01-12-18-31-nonprod-parity-ops.md
@@ -1,0 +1,121 @@
+## Actions Taken
+- Note: CLI command timestamps were not captured in the chat; filename timestamp is UTC 2026-01-12 18:31.
+- Verified AWS identity.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws sts get-caller-identity`
+  Output: `{"Account":"959713283130","Arn":"arn:aws:iam::959713283130:user/mnemosys-admin"}`
+- Checked for existing test RDS instance.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].DBInstanceStatus" --output text`
+  Output: `DBInstanceNotFound` error.
+- Attempted RDS create with explicit IOPS/throughput.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds create-db-instance --db-instance-identifier mnemosys-test-postgres --db-instance-class db.t4g.large --engine postgres --engine-version 16.11 --db-name mnemosys_test --allocated-storage 200 --storage-type gp3 --iops 3000 --storage-throughput 125 --backup-retention-period 35 --multi-az --publicly-accessible --storage-encrypted --deletion-protection --enable-performance-insights --performance-insights-retention-period 7 --db-subnet-group-name default-vpc-06f003b77e593c99a --vpc-security-group-ids sg-0463c511b48bcbef5`
+  Output: `InvalidParameterCombination: You can't specify IOPS or storage throughput for engine postgres and a storage size less than 400.`
+- Created test RDS instance without explicit IOPS/throughput.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds create-db-instance --db-instance-identifier mnemosys-test-postgres --db-instance-class db.t4g.large --engine postgres --engine-version 16.11 --db-name mnemosys_test --allocated-storage 200 --storage-type gp3 --backup-retention-period 35 --multi-az --publicly-accessible --storage-encrypted --deletion-protection --enable-performance-insights --performance-insights-retention-period 7 --db-subnet-group-name default-vpc-06f003b77e593c99a --vpc-security-group-ids sg-0463c511b48bcbef5`
+  Output: `"DBInstanceIdentifier":"mnemosys-test-postgres","DBInstanceStatus":"creating","MultiAZ":true` (truncated).
+- Waited for RDS availability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds wait db-instance-available --db-instance-identifier mnemosys-test-postgres` (timed out after 600s)
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].DBInstanceStatus" --output text` -> `modifying`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds wait db-instance-available --db-instance-identifier mnemosys-test-postgres` (succeeded; no output)
+- Retrieved endpoint and updated SSM parameters.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].Endpoint.Address" --output text`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm put-parameter --name /mnemosys/test/db/host --type SecureString --value "${TEST_ENDPOINT}" --overwrite`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm put-parameter --name /mnemosys/test/db/port --type SecureString --value "5432" --overwrite`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm put-parameter --name /mnemosys/test/db/database --type SecureString --value "mnemosys_test" --overwrite`
+  Output: endpoint `mnemosys-test-postgres.c3uamoeq6wst.us-east-2.rds.amazonaws.com`; SSM responses `{"Version":2,"Tier":"Standard"}` (x3).
+- Forced test ECS deployment and waited for stability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs update-service --cluster mnemosys-nonprod --service mnemosys-test-api --force-new-deployment`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs wait services-stable --cluster mnemosys-nonprod --services mnemosys-test-api`
+  Output: waiter failed `Waiter ServicesStable failed: Max attempts exceeded`.
+- Investigated ECS failures.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs list-tasks --cluster mnemosys-nonprod --service-name mnemosys-test-api --desired-status STOPPED --max-items 5`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs describe-tasks --cluster mnemosys-nonprod --tasks <task-arns> --query "tasks[*].{taskArn:taskArn,lastStatus:lastStatus,stoppedReason:stoppedReason,containers:containers[*].{name:name,exitCode:exitCode,reason:reason}}" --output json`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs get-log-events --log-group-name /mnemosys/test/api --log-stream-name mnemosys/mnemosys-api/b4158f108f9e4d7d8a588857386c0d7a --limit 50 --no-start-from-head --query "events[*].message" --output json`
+  Output: tasks exited with `exitCode: 1`; log excerpt shows `sqlalchemy.exc.ProgrammingError: ... schema "mnemosys" does not exist` (truncated).
+- Created schema in new test database and conditionally granted access.
+  Command:
+  - `ADMIN_USER=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db_admin/username --with-decryption --query "Parameter.Value" --output text)`
+  - `ADMIN_PASS=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db_admin/password --with-decryption --query "Parameter.Value" --output text)`
+  - `APP_USER=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/username --with-decryption --query "Parameter.Value" --output text)`
+  - `DB_HOST=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/host --with-decryption --query "Parameter.Value" --output text)`
+  - `DB_NAME=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/database --with-decryption --query "Parameter.Value" --output text)`
+  - `DB_SSLMODE=$(AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ssm get-parameter --name /mnemosys/test/db/sslmode --with-decryption --query "Parameter.Value" --output text)`
+  - `PGPASSWORD="$ADMIN_PASS" psql "host=$DB_HOST dbname=$DB_NAME user=$ADMIN_USER sslmode=$DB_SSLMODE" -v ON_ERROR_STOP=1 -c "CREATE SCHEMA IF NOT EXISTS mnemosys;"`
+  - `ROLE_EXISTS=$(PGPASSWORD="$ADMIN_PASS" psql "host=$DB_HOST dbname=$DB_NAME user=$ADMIN_USER sslmode=$DB_SSLMODE" -tAc "SELECT 1 FROM pg_roles WHERE rolname='${APP_USER}';")`
+  - `PGPASSWORD="$ADMIN_PASS" psql "host=$DB_HOST dbname=$DB_NAME user=$ADMIN_USER sslmode=$DB_SSLMODE" -v ON_ERROR_STOP=1 -c "GRANT USAGE, CREATE ON SCHEMA mnemosys TO \"${APP_USER}\";"` (conditional)
+  Output: `CREATE SCHEMA`.
+- Forced ECS deployment again and waited for stability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs update-service --cluster mnemosys-nonprod --service mnemosys-test-api --force-new-deployment`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs wait services-stable --cluster mnemosys-nonprod --services mnemosys-test-api`
+  Output: waiter succeeded (no output).
+- Updated test ECS baseline and waited for stability.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs update-service --cluster mnemosys-nonprod --service mnemosys-test-api --desired-count 2 --health-check-grace-period-seconds 180 --deployment-configuration "minimumHealthyPercent=100,maximumPercent=200,deploymentCircuitBreaker={enable=true,rollback=true}"`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs wait services-stable --cluster mnemosys-nonprod --services mnemosys-test-api`
+  Output: wait succeeded (no output).
+- Verified autoscaling, health checks, and final RDS config.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws application-autoscaling describe-scalable-targets --service-namespace ecs --resource-ids service/mnemosys-nonprod/mnemosys-test-api --query "ScalableTargets" --output json`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws elbv2 describe-load-balancers --names mnemosys-nonprod-alb --query "LoadBalancers[0].DNSName" --output text`
+  - `curl -fsSL http://mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com/health/`
+  - `curl -fsSL http://mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com:8080/health/`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws rds describe-db-instances --db-instance-identifier mnemosys-test-postgres --query "DBInstances[0].{status:DBInstanceStatus,engine:Engine,engineVersion:EngineVersion,instanceClass:DBInstanceClass,allocatedStorage:AllocatedStorage,iops:Iops,storageThroughput:StorageThroughput,multiAZ:MultiAZ,backupRetention:BackupRetentionPeriod,public:PubliclyAccessible,deletionProtection:DeletionProtection,performanceInsights:PerformanceInsightsEnabled,storageType:StorageType,endpoint:Endpoint.Address}" --output json`
+  Output: autoscaling `[]`; health checks `{"status":"ok"}`; RDS `status: available`, `MultiAZ: true`, `allocatedStorage: 200`, `backupRetention: 35`, endpoint `mnemosys-test-postgres.c3uamoeq6wst.us-east-2.rds.amazonaws.com` (truncated).
+- Checked migration gate outcomes in logs.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs filter-log-events --log-group-name /mnemosys/test/api --filter-pattern "Command finished with code" --limit 20 --query "events[*].message" --output json`
+  Output: includes `Command finished with code 0 in 4.98s: /usr/local/bin/python -m alembic upgrade heads` (truncated).
+- Inspected deploy workflow for release/test mapping.
+  Command: `cat .github/workflows/deploy-nonprod.yml`
+  Output: `on: push: branches: [develop, release]` and `release -> test` mapping (truncated).
+- Compared release vs develop history to scope the release promotion.
+  Commands:
+  - `git fetch origin`
+  - `git log --oneline origin/release..origin/develop`
+  Output: multiple commits ahead of release (truncated).
+- Searched test task logs for migration gate outcomes (per-task log streams).
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs list-tasks --cluster mnemosys-nonprod --service-name mnemosys-test-api --desired-status RUNNING --query "taskArns" --output text`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs get-log-events --log-group-name /mnemosys/test/api --log-stream-name mnemosys/mnemosys-api/<task-id> --limit 200 --no-start-from-head --query "events[*].message" --output text | rg -n "alembic|Migration runner|Command finished"`
+  Output: `Command finished with code 255 ... alembic check` (e.g., `Target database is not up to date`, `remove_table alembic_version`), followed by `Command finished with code 0 ... alembic upgrade heads` and successful startup logs (truncated).
+- Ran local validation on develop; first attempt failed due to missing Docker daemon.
+  Command: `python3 scripts/dev/validate_local.py`
+  Output: `docker.errors.DockerException: Error while fetching server API version: ... FileNotFoundError(2, 'No such file or directory')` (truncated).
+- Re-ran local validation after Docker started.
+  Command: `python3 scripts/dev/validate_local.py`
+  Output: `184 passed in 24.46s` with coverage 100% and ruff/mypy success (truncated).
+
+## Outcomes and Status
+- Test RDS instance `mnemosys-test-postgres` created and available; config matches locked baseline (db.t4g.large, gp3 200GB, Multi-AZ true, backup retention 35, deletion protection true, Performance Insights enabled).
+- `/mnemosys/test/db/host`, `/mnemosys/test/db/port`, and `/mnemosys/test/db/database` updated to the new RDS endpoint.
+- ECS test service stabilized after schema creation; service now at desired 2 / running 2 with circuit breaker enabled and health check grace 180s.
+- Autoscaling remains off (no scalable targets).
+- ALB health checks return `{"status":"ok"}` for dev (port 80) and test (port 8080).
+- Migration gate now shows `alembic check` failures in test task logs (target DB not up to date / remove `alembic_version`), followed by successful `alembic upgrade heads`.
+- Local validation on develop succeeded after Docker startup.
+- Release -> test pipeline validation remains pending (release is behind develop and requires PR-based promotion).
+
+## Problems Encountered and Solved
+- RDS create failed with `InvalidParameterCombination` when specifying IOPS/throughput at 200GB; resolved by omitting explicit IOPS/throughput (gp3 defaults applied).
+- RDS wait timed out while instance still `modifying`; resolved by rechecking status and waiting again.
+- ECS tasks exited with code 1 due to `schema "mnemosys" does not exist`; resolved by creating the schema in the new test database and redeploying.
+- CloudWatch log retrieval initially failed with `Unknown options: false` for `--start-from-head false` and with `ResourceNotFoundException` for a missing log stream; resolved by using `--no-start-from-head` and targeting an existing log stream.
+- Local validation failed due to Docker daemon not running; resolved by starting Docker and rerunning `validate_local.py`.
+
+## Problems Unresolved
+- `alembic check` fails in test task logs (e.g., `Target database is not up to date` and `remove_table alembic_version`), indicating bootstrap/migration gate issues that need triage.
+- Release -> test pipeline validation not run; promotion requires PR from develop to release.
+
+## Changes and Artifacts
+- Created RDS instance `mnemosys-test-postgres` (new dedicated test DB).
+- Updated SSM parameters `/mnemosys/test/db/host`, `/mnemosys/test/db/port`, `/mnemosys/test/db/database` to the new endpoint.
+- Created schema `mnemosys` in the new test database (and conditionally granted schema privileges to the app user if present).
+- Updated ECS service `mnemosys-test-api` to desired count 2 with deployment circuit breaker enabled and health check grace period 180s.
+- Created `docs/operations/2026-01-12-18-31-nonprod-parity-ops.md` (this summary).
+
+## Follow-up Work and New Issues
+- Triage `alembic check` failures in test bootstrap (especially `alembic_version` removal) and determine corrective action.
+- Run release -> test pipeline validation (develop -> release PR and deploy) after triage and capture migration gate evidence.

--- a/docs/operations/2026-01-13-13-50-deployment-validation.md
+++ b/docs/operations/2026-01-13-13-50-deployment-validation.md
@@ -1,0 +1,46 @@
+## Actions Taken
+- Note: CLI command timestamps were not captured in the chat; filename timestamp is UTC 2026-01-13 13:50.
+- Prepared the release promotion and patch bump PRs from `develop`.
+  Command: `python3 scripts/dev/submit_release_prs.py`
+  Output: created `promotion/release-0-1-2-0-20260113134241`, validated locally (184 tests, 100% coverage),
+  and opened PRs `#84` (release promotion) and `#85` (patch bump).
+- Merged the release promotion and patch bump PRs with merge commits.
+  Commands:
+  - `gh pr merge 84 --merge --delete-branch`
+  - `gh pr merge 85 --merge --delete-branch`
+  Output: release merge commit `517c61313cdda1d5435e5ecfb9fd84626a925dc1`, develop merge commit
+  `1a8668266e8defe36a25fc5c152344cd6c529623`.
+- Verified GitHub Actions deployment runs for release and develop.
+  Commands:
+  - `gh run view 20958961737 --json status,conclusion,url,headSha,displayTitle`
+  - `gh run view 20958971093 --json status,conclusion,url,headSha,displayTitle`
+  Output: both runs completed with `conclusion: success`.
+- Verified ECS service stability after deploys.
+  Command: `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws ecs describe-services --cluster mnemosys-nonprod --services mnemosys-dev-api mnemosys-test-api --query "services[*].{name:serviceName,status:status,desired:desiredCount,running:runningCount}" --output json`
+  Output: dev `desired 1 / running 1`, test `desired 2 / running 2`.
+- Verified ALB health endpoints for development and test.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws elbv2 describe-load-balancers --names mnemosys-nonprod-alb --query "LoadBalancers[0].DNSName" --output text`
+  - `curl -fsSL http://mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com/health/`
+  - `curl -fsSL http://mnemosys-nonprod-alb-1104521642.us-east-2.elb.amazonaws.com:8080/health/`
+  Output: both health checks returned `{"status":"ok"}`.
+- Verified migration gate activity in dev/test logs.
+  Commands:
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs describe-log-streams --log-group-name /mnemosys/test/api --order-by LastEventTime --descending --max-items 1 --query "logStreams[0].logStreamName" --output text`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs get-log-events --log-group-name /mnemosys/test/api --log-stream-name <stream> --limit 200 --start-from-head --query "events[*].message" --output text | rg -n "alembic"`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs describe-log-streams --log-group-name /mnemosys/dev/api --order-by LastEventTime --descending --max-items 1 --query "logStreams[0].logStreamName" --output text`
+  - `AWS_PROFILE=mnemosys-admin AWS_REGION=us-east-2 aws logs get-log-events --log-group-name /mnemosys/dev/api --log-stream-name <stream> --limit 200 --start-from-head --query "events[*].message" --output text | rg -n "alembic"`
+  Output: test shows `alembic current` at `f71a73e20503`, `alembic heads` at `abe7b3773eff`,
+  then `alembic upgrade heads` and `alembic current` at head; dev shows `alembic current` and
+  `alembic heads` both at `abe7b3773eff` (no upgrade needed).
+
+## Outcomes and Status
+- Release promotion deployed to test and patch bump deployed to development via GitHub Actions.
+- ECS services report expected desired/running counts and ALB health checks are green.
+- Migration gate runs on both environments; upgrades succeed.
+
+## Problems Encountered and Solved
+- None.
+
+## Problems Unresolved
+- None.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,6 +15,14 @@ This repository is documentation-first and focused on Mnemosys operations.
 - `standards-and-conventions.md`: canonical standards references and local
   overlays.
 - `repository-bootstrap.md`: summary of bootstrap decisions and open questions.
+- `aws/`: AWS runbooks and bootstrap procedures.
+- `aws/nonprod-rest-api-deploy-plan.md`: nonprod REST API deployment plan.
+- `aws/database-environment-setup.md`: RDS bootstrap and environment setup.
+- `aws/test-prod-db-parity-plan.md`: test/production parity plan (consolidated).
+- `operations/`: operational execution logs and validation records.
+- `policies/`: operational constraints and bootstrap policies.
+- `plans/complete/aws-ops-doc-migration.md`: plan and execution record for
+  migrating AWS operations docs from mnemosys-core.
 - `decisions/README.md`: ADR location and format.
 - `decisions/0001-application-classification-and-co-release.md`: application
   classification and release alignment decision.

--- a/docs/plans/complete/aws-ops-doc-migration.md
+++ b/docs/plans/complete/aws-ops-doc-migration.md
@@ -1,0 +1,119 @@
+# AWS Operations Documentation Migration Plan
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Source inventory](#source-inventory)
+- [Target structure](#target-structure)
+- [Migration map](#migration-map)
+- [Plan](#plan)
+  - [Phase 0: Decisions before execution](#phase-0-decisions-before-execution)
+  - [Phase 1: Prepare target structure](#phase-1-prepare-target-structure)
+  - [Phase 2: Migrate documents](#phase-2-migrate-documents)
+  - [Phase 3: Update references](#phase-3-update-references)
+  - [Phase 4: Validate and close](#phase-4-validate-and-close)
+- [Validation checks](#validation-checks)
+- [Risks and mitigations](#risks-and-mitigations)
+- [Open questions](#open-questions)
+- [Status](#status)
+
+## Purpose
+Define a concrete plan to migrate AWS operations documentation from
+mnemosys-core into mnemosys-operations and record the executed steps.
+
+## Scope
+- AWS operations runbooks, bootstrap procedures, and operational logs.
+- Operational exceptions embedded in architecture or schema design docs.
+- Link and ownership updates after migration.
+
+Out of scope:
+- Non-AWS operational docs unrelated to infrastructure.
+- Code or tooling changes.
+
+## Source inventory
+Target sources in mnemosys-core (read-only until execution):
+- `docs/architecture/MNEMOSYS_Infrastructure_and_Platform_Decisions.md`
+- `docs/project/final/Database_Environment_Setup.md`
+- `docs/plans/complete/2026-01-04-aws-nonprod-rest-api-deploy-plan.md`
+- `docs/plans/complete/2026-01-07-test-prod-db-parity-plan.md` (stub pointing to the consolidated plan)
+- `docs/operations/2026-01-12-18-31-nonprod-parity-ops.md`
+- `docs/operations/2026-01-13-13-50-deployment-validation.md`
+- `docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md` (operational constraints section)
+
+## Target structure
+Proposed mnemosys-operations layout:
+- `docs/aws/`: AWS runbooks and bootstrap procedures.
+- `docs/operations/`: operational execution logs and validation records.
+- `docs/policies/`: operational policy constraints and exceptions.
+
+## Migration map
+- `docs/plans/complete/2026-01-04-aws-nonprod-rest-api-deploy-plan.md`
+  -> `docs/aws/nonprod-rest-api-deploy-plan.md`
+- `docs/project/final/Database_Environment_Setup.md`
+  -> `docs/aws/database-environment-setup.md`
+- `docs/operations/2026-01-12-18-31-nonprod-parity-ops.md`
+  -> `docs/operations/2026-01-12-18-31-nonprod-parity-ops.md`
+- `docs/operations/2026-01-13-13-50-deployment-validation.md`
+  -> `docs/operations/2026-01-13-13-50-deployment-validation.md`
+- Extract operational exceptions from
+  `docs/architecture/MNEMOSYS_Infrastructure_and_Platform_Decisions.md`
+  -> `docs/policies/aws-bootstrap-exceptions.md`
+- Extract operational constraints from
+  `docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md`
+  -> `docs/policies/aws-db-bootstrap-constraints.md`
+- Keep `docs/plans/complete/2026-01-07-test-prod-db-parity-plan.md` as a stub in
+  mnemosys-core or migrate the stub to mnemosys-operations (decision needed).
+
+## Plan
+
+### Phase 0: Decisions before execution
+- Confirm the target directory structure (`docs/aws`, `docs/operations`,
+  `docs/policies`) and naming.
+- Confirm whether mnemosys-core should retain stubs that link to the new
+  mnemosys-operations locations.
+- Confirm whether any AWS identifiers must be redacted or moved to a separate
+  private doc before migration.
+
+### Phase 1: Prepare target structure
+- Create the target directories in mnemosys-operations.
+- Add placeholder README files if needed to explain each area.
+
+### Phase 2: Migrate documents
+- Copy the runbook and operations documents into the new locations.
+- Extract operational exceptions and constraints into policy docs.
+- Preserve history and timestamps in file names and content.
+
+### Phase 3: Update references
+- In mnemosys-core, replace moved content with links to the new locations.
+- Ensure architecture and schema docs reference the new policy docs instead of
+  embedding operational exceptions.
+- Update any cross-links inside migrated docs to point to the new paths.
+
+### Phase 4: Validate and close
+- Verify all moved docs include Tables of Contents per standards.
+- Confirm no broken links remain in either repository.
+- Record the migration decision in a new ADR (if required).
+
+## Validation checks
+- `rg -n "docs/aws|docs/operations|docs/policies" docs` in mnemosys-operations.
+- `rg -n "mnemosys-operations" docs` in mnemosys-core to confirm link updates.
+- Manual spot-check of each migrated document for TOC and link accuracy.
+
+## Risks and mitigations
+- Drift between core and operations docs.
+  Mitigation: replace core content with explicit links and a single source of
+  truth.
+- Sensitive identifiers embedded in runbooks.
+  Mitigation: confirm redaction policy before migration.
+- Over-splitting architecture vs operations.
+  Mitigation: keep architecture decisions in core, move procedures to ops.
+
+## Open questions
+- Should mnemosys-core keep stubs for migrated docs or only link from a single
+  index page?
+- Do we need a dedicated "runbooks" section instead of `docs/aws`?
+- Which AWS identifiers are safe to keep in public docs?
+- Should the parity plan stub move with the consolidated deploy plan?
+
+## Status
+Completed. Migration executed and references updated.

--- a/docs/policies/aws-bootstrap-exceptions.md
+++ b/docs/policies/aws-bootstrap-exceptions.md
@@ -1,0 +1,43 @@
+# AWS Bootstrap Exceptions
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Bootstrap exceptions](#bootstrap-exceptions)
+- [Account model](#account-model)
+- [Bootstrap end trigger](#bootstrap-end-trigger)
+- [References](#references)
+
+## Purpose
+Document the operational exceptions and constraints that apply during the AWS
+bootstrap phase.
+
+## Scope
+Applies to AWS infrastructure used for MNEMOSYS development, test, and
+production environments during bootstrap.
+
+## Bootstrap exceptions
+- Temporary public database access is permitted only for controlled bootstrap
+  or diagnostics and must be removed afterward.
+- The development RDS instance may be made public with IP allowlisting to
+  provision and use `mnemosys_sandbox`.
+- Local environments must store only sandbox credentials.
+- Sandbox roles must be denied `CONNECT` on `mnemosys_dev`.
+- Development and test databases may share the existing non-production RDS
+  instance during bootstrap, but test must move to a dedicated RDS instance
+  before any external users are granted access.
+
+## Account model
+- All environments share a single AWS account during bootstrap.
+- A single console/CLI IAM user (`mnemosys-admin`) is used for access.
+- The account model may be split into non-prod and prod accounts later if
+  scale or risk demands it.
+
+## Bootstrap end trigger
+Bootstrap ends when end-to-end automation updates `mnemosys_dev` and restarts
+the REST API service. At that point, the development RDS instance must be fully
+locked down.
+
+## References
+- `docs/architecture/MNEMOSYS_Infrastructure_and_Platform_Decisions.md` in
+  https://github.com/wphillipmoore/mnemosys-core

--- a/docs/policies/aws-db-bootstrap-constraints.md
+++ b/docs/policies/aws-db-bootstrap-constraints.md
@@ -1,0 +1,47 @@
+# AWS Database Bootstrap Constraints
+
+## Table of Contents
+- [Purpose](#purpose)
+- [Scope](#scope)
+- [Environment access model](#environment-access-model)
+- [Credential and access rules](#credential-and-access-rules)
+- [Bootstrap exit checklist](#bootstrap-exit-checklist)
+- [References](#references)
+
+## Purpose
+Capture database access constraints and bootstrap rules for AWS-hosted MNEMOSYS
+databases.
+
+## Scope
+Applies to RDS-backed environments and the credentials used by automation and
+local development.
+
+## Environment access model
+- `mnemosys_dev` is API-only access and mirrors test/production constraints.
+- `mnemosys_sandbox` is admin-accessible for schema testing and validation.
+- `mnemosys_test` is API-only access and updated only by release automation.
+- Local environments must not store test credentials.
+- During bootstrap, `mnemosys_test` may share the non-production RDS instance
+  with `mnemosys_dev` and `mnemosys_sandbox`.
+- Before any external users access test, `mnemosys_test` must move to a
+  dedicated RDS instance with separate network access controls.
+
+## Credential and access rules
+- Alembic tooling uses admin credentials via `MNEMOSYS_DB_ADMIN_*`; if unset,
+  it falls back to `MNEMOSYS_DB_*`.
+- The REST API uses non-admin credentials via `MNEMOSYS_DB_*` only.
+- The development deployment database remains API-only; direct admin access is
+  not assumed.
+- Bootstrap public access exceptions are defined in
+  `docs/policies/aws-bootstrap-exceptions.md`.
+
+## Bootstrap exit checklist
+- Disable public access on the development RDS instance.
+- Remove temporary inbound rules (TCP 5432) from security groups.
+- Rotate admin credentials and store them outside local `.env`.
+- Ensure local environments only reference sandbox credentials.
+- Verify `mnemosys_dev` accepts connections only from the REST API runtime role.
+
+## References
+- `docs/plans/in-progress/2026-01-03-alembic-schema-management-design.md` in
+  https://github.com/wphillipmoore/mnemosys-core


### PR DESCRIPTION
## Summary
- migrate AWS runbooks and bootstrap docs into `docs/aws`
- add operational policy docs for bootstrap exceptions and DB constraints
- move migration plan to completed status and update doc map
- add AWS operations logs under `docs/operations`

## Testing
- not run (docs-only changes)
