### PR TITLE
Adopt standards include bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # MNEMOSYS Operations
 
+#include standards-and-conventions.md
+
 ## User Overrides (Optional)
 
 If `~/AGENTS.md` exists and is readable, load it and apply it as a

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -5,80 +5,10 @@ https://github.com/wphillipmoore/standards-and-conventions
 
 ## Table of Contents
 - [Canonical references](#canonical-references)
-  - [Core references (always required)](#core-references-always-required)
-  - [Repository-type references (required for the declared type)](#repository-type-references-required-for-the-declared-type)
-  - [Additional required references](#additional-required-references)
 - [Project-specific overlay](#project-specific-overlay)
-  - [Repository profile](#repository-profile)
-  - [AI co-authors](#ai-co-authors)
-  - [Versioning alignment](#versioning-alignment)
-  - [Release environments](#release-environments)
-  - [Local validation](#local-validation)
-  - [Tooling requirement](#tooling-requirement)
-  - [Local deviations](#local-deviations)
 
 ## Canonical references
-
-### Core references (always required)
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/markdown-standards.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/repository-types-and-attributes.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/commit-messages-and-authorship.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/github-issues.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/source-control-guidelines.md
-
-### Repository-type references (required for the declared type)
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/branching-and-deployment.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/application-versioning-scheme.md
-
-### Additional required references
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/overview.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/release-versioning.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/hotfix-policy.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/overview.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/environment-and-tooling.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/overview.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/naming-conventions.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/import-time-side-effects.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/type-hints.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/development/python/testing-and-coverage.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/repository/overview.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/repository/repository-structure.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/architecture-standards.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-code-review-guidelines.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/ai-assisted-development-loop.md
+#include ../standards-and-conventions/docs/standards-and-conventions.md
 
 ## Project-specific overlay
-
-### Repository profile
-
-- repository_type: application
-- versioning_scheme: application
-- branching_model: application-promotion
-- release_model: environment-promotion
-- supported_release_lines: single
-
-### AI co-authors
-
-None documented.
-
-### Versioning alignment
-
-MAJOR.MINOR synced with mnemosys-core; PATCH.BUILD are repo-specific.
-
-### Release environments
-
-Develop, test, production.
-
-### Local validation
-
-- `python3 scripts/dev/validate_local.py`
-- Docs-only changes: `python3 scripts/dev/validate_docs.py`
-
-### Tooling requirement
-
-- `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`).
-
-### Local deviations
-
-None.
+#include repository-standards.md

--- a/repository-standards.md
+++ b/repository-standards.md
@@ -1,0 +1,37 @@
+# Mnemosys Operations Repository Standards
+
+## Table of Contents
+- [Repository profile](#repository-profile)
+- [AI co-authors](#ai-co-authors)
+- [Versioning alignment](#versioning-alignment)
+- [Release environments](#release-environments)
+- [Local validation](#local-validation)
+- [Tooling requirement](#tooling-requirement)
+- [Local deviations](#local-deviations)
+
+## Repository profile
+- repository_type: application
+- versioning_scheme: application
+- branching_model: application-promotion
+- release_model: environment-promotion
+- supported_release_lines: single
+
+## AI co-authors
+- Co-Authored-By: mnemosys-codex <252598091+mnemosys-codex@users.noreply.github.com>
+- Co-Authored-By: mnemosys-claude <252602472+mnemosys-claude@users.noreply.github.com>
+
+## Versioning alignment
+MAJOR.MINOR synced with mnemosys-core; PATCH.BUILD are repo-specific.
+
+## Release environments
+Develop, test, production.
+
+## Local validation
+- `python3 scripts/dev/validate_local.py`
+- Docs-only changes: `python3 scripts/dev/validate_docs.py`
+
+## Tooling requirement
+- `uv` `0.9.26` (install with `python3 -m pip install uv==0.9.26`).
+
+## Local deviations
+None.

--- a/standards-and-conventions.md
+++ b/standards-and-conventions.md
@@ -1,0 +1,7 @@
+# Mnemosys Operations Standards Bootstrap
+
+## Table of Contents
+- [Includes](#includes)
+
+## Includes
+#include docs/standards-and-conventions.md


### PR DESCRIPTION
# Pull Request

## Summary
- Adopt include-based standards bootstrap and repository-standards overlay.
- Refresh AGENTS to pull standards via includes.

## Issue Linkage
- Fixes #16

## Testing
- Docs-only: tests skipped.
- `python3 scripts/dev/validate_docs.py` failed: markdownlint version mismatch (expected 0.41.0, found 0.47.0).
- Files changed:
  - AGENTS.md
  - docs/standards-and-conventions.md
  - repository-standards.md
  - standards-and-conventions.md

## Notes
- None.
